### PR TITLE
LIBFCREPO-902. Created AddBearerAuthorizationProcessor.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <jena.version>3.16.0</jena.version>
     <junit.version>4.13</junit.version>
     <ldpath.version>3.3.0</ldpath.version>
-    <spring.version>5.2.9.RELEASE</spring.version>
+    <spring.version>4.3.18.RELEASE</spring.version>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,13 @@
 
   <dependencies>
     <dependency>
+      <groupId>edu.umd.lib</groupId>
+      <artifactId>umd-fcrepo-webapp</artifactId>
+      <version>2.5.0-SNAPSHOT</version>
+      <classifier>classes</classifier>
+      <type>jar</type>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>${junit.version}</version>

--- a/src/main/java/edu/umd/lib/camel/processors/AddBearerAuthorizationProcessor.java
+++ b/src/main/java/edu/umd/lib/camel/processors/AddBearerAuthorizationProcessor.java
@@ -1,0 +1,39 @@
+package edu.umd.lib.camel.processors;
+
+import edu.umd.lib.fcrepo.AuthTokenService;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.Processor;
+
+import java.util.Date;
+
+import static edu.umd.lib.fcrepo.LdapRoleLookupService.ADMIN_ROLE;
+import static java.time.Instant.now;
+import static java.time.temporal.ChronoUnit.HOURS;
+
+public class AddBearerAuthorizationProcessor implements Processor {
+  public final static String SUBJECT = "camel";
+
+  public final static String USERNAME_HEADER_NAME = "CamelFcrepoUser";
+
+  private AuthTokenService authTokenService;
+
+  public AddBearerAuthorizationProcessor() {}
+
+  public AuthTokenService getAuthTokenService() {
+    return authTokenService;
+  }
+
+  public void setAuthTokenService(AuthTokenService authTokenService) {
+    this.authTokenService = authTokenService;
+  }
+
+  @Override
+  public void process(Exchange exchange) throws Exception {
+    final Message in = exchange.getIn();
+    final String issuer = in.getHeader(USERNAME_HEADER_NAME, String.class);
+    final Date expirationDate = Date.from(now().plus(1, HOURS));
+    final String token = authTokenService.createToken(SUBJECT, issuer, expirationDate, ADMIN_ROLE);
+    in.setHeader("Authorization", "Bearer " + token);
+  }
+}


### PR DESCRIPTION
Adds an "Authorization: Bearer {token}" header to the message. The token generated has the "fedoraAdmin" role and is good for 1 hour.

https://issues.umd.edu/browse/LIBFCREPO-902