### PR TITLE
LIBFCREPO-909. Added a DescriptionURI processor.

### DIFF
--- a/src/main/java/edu/umd/lib/camel/processors/DescriptionURI.java
+++ b/src/main/java/edu/umd/lib/camel/processors/DescriptionURI.java
@@ -1,0 +1,34 @@
+package edu.umd.lib.camel.processors;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.Processor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.core.Link;
+import java.io.Serializable;
+import java.util.List;
+
+public class DescriptionURI implements Processor, Serializable {
+  private static final Logger logger = LoggerFactory.getLogger(DescriptionURI.class);
+
+  public static final String DESCRIBED_BY_HEADER = "DescribedBy";
+
+  @Override
+  public void process(Exchange exchange) {
+    final Message in = exchange.getIn();
+    final List<?> linkHeaders = in.getHeader("Link", List.class);
+    logger.debug("Link headers: {}", linkHeaders);
+    for (final Object h : linkHeaders) {
+      logger.debug("Parsing header: {}", h);
+      final Link link = Link.valueOf((String) h);
+      logger.debug("URI = {}", link.getUri());
+      logger.debug("Rel = {}", link.getRel());
+      if (link.getRel().equals("describedby")) {
+        in.setHeader(DESCRIBED_BY_HEADER, link.getUri().toString());
+        break;
+      }
+    }
+  }
+}


### PR DESCRIPTION
Check for Link rel="describedby" header and add it to the DescribedBy message header.

https://issues.umd.edu/browse/LIBFCREPO-909