### PR TITLE
LIBFCREPO-915. Set character set encoding used by Exchange object

### DIFF
--- a/src/main/java/edu/umd/lib/camel/processors/LdpathProcessor.java
+++ b/src/main/java/edu/umd/lib/camel/processors/LdpathProcessor.java
@@ -188,6 +188,10 @@ public class LdpathProcessor implements Processor, Serializable {
     logger.debug("Removing {} from linkedDataMapKey", resourceURI);
     provider.removeLinkedDataMapping(resourceURI);
 
+    // Force the Exchange to use UTF-8, otherwise Japanese characters are not
+    // passed properly to Solr.
+    exchange.setProperty(Exchange.CHARSET_NAME, "UTF-8");
+    
     // Add the JSON result to the message
     in.setBody(jsonResult, String.class);
     in.setHeader("Content-Type", "application/json");


### PR DESCRIPTION
Set the character set encoding for the Exchange object to be UTF-8.

This is needed so that Japanese characters in the JSON string are passed
correctly to Solr.

https://issues.umd.edu/browse/LIBFCREPO-915