### PR TITLE
LIBFCREPO-1111. Change INFO-level logging statements to DEBUG.

### DIFF
--- a/src/main/java/edu/umd/lib/camel/processors/LdpathProcessor.java
+++ b/src/main/java/edu/umd/lib/camel/processors/LdpathProcessor.java
@@ -151,8 +151,10 @@ public class LdpathProcessor implements Processor, Serializable {
     headers.add(new BasicHeader(AUTHORIZATION, "Bearer " + authToken));
     headers.add(new BasicHeader("X-Forwarded-Host", forwardedHost));
     headers.add(new BasicHeader("X-Forwarded-Proto", forwardedProto));
-    for (Header h : headers) {
-      logger.info("HTTP client header: {}: {}", h.getName(), h.getValue());
+    if (logger.isDebugEnabled()) {
+      for (final Header h : headers) {
+        logger.debug("HTTP client header: {}: {}", h.getName(), h.getValue());
+      }
     }
 
     // Configure HttpClient for making resource request
@@ -170,7 +172,7 @@ public class LdpathProcessor implements Processor, Serializable {
     final LDCacheBackend cacheBackend = new LDCacheBackend(new LDCache(cacheConfig, cachingBackend));
     final LDPath<Value> ldpath = new LDPath<>(cacheBackend);
 
-    logger.info("Sending request to {} for {}", containerBasedUri, resourceURI);
+    logger.debug("Sending request to {} for {}", containerBasedUri, resourceURI);
     logger.debug("LDPath query: {}", query);
     String jsonResult;
     try {
@@ -236,7 +238,7 @@ public class LdpathProcessor implements Processor, Serializable {
       String describedBy = null;
       boolean nonRdfSource = false;
       for (Header h: headers) {
-        logger.debug("header:{} ", h);
+        logger.debug("Response header: {}: {}", h.getName(), h.getValue());
         if ("link".equalsIgnoreCase(h.getName())) {
           Link link = Link.valueOf(h.getValue());
           String rel = link.getRel();

--- a/src/main/java/edu/umd/lib/camel/processors/SparqlQueryProcessor.java
+++ b/src/main/java/edu/umd/lib/camel/processors/SparqlQueryProcessor.java
@@ -46,20 +46,20 @@ public class SparqlQueryProcessor implements Processor, Serializable {
     final Map<String, RDFNode> bindings = new HashMap<>();
 
     // process headers for runtime bindings
-    logger.info("Checking headers for binding definitions");
+    logger.debug("Checking headers for binding definitions");
     for (Map.Entry<String, Object> entry : message.getHeaders().entrySet()) {
       final String key = entry.getKey();
       logger.trace("Found key {}", key);
       if (key.matches("^CamelSparqlQueryBinding-Literal-.+")) {
         final String bindingName = extractBindingName(key);
         final String bindingValue = (String) entry.getValue();
-        logger.info("Binding ?{} to literal: \"{}\"", bindingName, bindingValue);
+        logger.debug("Binding ?{} to literal: \"{}\"", bindingName, bindingValue);
         bindings.put(bindingName, model.createLiteral(bindingValue));
       }
       if (key.matches("^CamelSparqlQueryBinding-URI-.+")) {
         final String bindingName = extractBindingName(key);
         final String bindingValue = (String) entry.getValue();
-        logger.info("Binding ?{} to URI {}", bindingName, bindingValue);
+        logger.debug("Binding ?{} to URI {}", bindingName, bindingValue);
         bindings.put(bindingName, model.createResource(bindingValue));
       }
     }

--- a/src/main/java/edu/umd/lib/camel/utils/LinkHeaders.java
+++ b/src/main/java/edu/umd/lib/camel/utils/LinkHeaders.java
@@ -1,0 +1,55 @@
+package edu.umd.lib.camel.utils;
+
+import org.apache.http.Header;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.core.Link;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class LinkHeaders {
+    private static final Logger logger = LoggerFactory.getLogger(LinkHeaders.class);
+
+    final private List<Link> linkHeaders;
+
+    public LinkHeaders(final List<?> linkHeaders) {
+        this.linkHeaders = linkHeaders.stream().map(h -> Link.valueOf((String) h)).collect(Collectors.toList());
+    }
+
+    public LinkHeaders(final Header[] headers) {
+        this.linkHeaders = new ArrayList<>();
+        for (final Header h : headers) {
+            if ("link".equalsIgnoreCase(h.getName())) {
+                linkHeaders.add(Link.valueOf(h.getValue()));
+            }
+        }
+    }
+
+    /**
+     * Get the first URI in this set of link headers whose link relation equals the
+     * given rel value. If none is found, returns null.
+     *
+     * @param rel link relation name
+     * @return first URI found, or null
+     */
+    public URI getUriByRel(final String rel) {
+        final Optional<Link> link = linkHeaders.stream().filter(l -> l.getRel().equals(rel)).findFirst();
+        return link.map(Link::getUri).orElse(null);
+    }
+
+    /**
+     * Check if this set of links headers has a link matching the given rel value
+     * and containing the given uri.
+     *
+     * @param rel link relation name
+     * @param uri link target
+     * @return boolean
+     */
+    public boolean contains(final String rel, final String uri) {
+        return linkHeaders.stream().anyMatch(l -> l.getRel().equals(rel) && l.getUri().toString().contains(uri));
+    }
+}

--- a/src/test/java/edu/umd/lib/camel/utils/LinkHeadersTest.java
+++ b/src/test/java/edu/umd/lib/camel/utils/LinkHeadersTest.java
@@ -1,0 +1,46 @@
+package edu.umd.lib.camel.utils;
+
+import org.apache.http.Header;
+import org.apache.http.message.BasicHeader;
+import org.junit.Test;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class LinkHeadersTest {
+    @Test
+    public void testHeadersArrayConstructor() throws URISyntaxException {
+        final Header[] headers = {
+                new BasicHeader("Link", "<http://example.com/foo>; rel=\"describedby\""),
+                new BasicHeader("Link", "<http://example.com/modelA>; rel=\"type\""),
+                new BasicHeader("Content-Type", "text/plain")
+        };
+
+        final LinkHeaders linkHeaders = new LinkHeaders(headers);
+
+        assertEquals(new URI("http://example.com/foo"), linkHeaders.getUriByRel("describedby"));
+        assertNull(linkHeaders.getUriByRel("notalinkrelation"));
+
+        assertTrue(linkHeaders.contains("type", "http://example.com/modelA"));
+        assertFalse(linkHeaders.contains("type", "http://example.com/missingModel"));
+    }
+
+    @Test
+    public void testListConstructor() throws URISyntaxException {
+        final List<String> headerValues = new ArrayList<>();
+        headerValues.add("<http://example.com/foo>; rel=\"describedby\"");
+        headerValues.add("<http://example.com/modelA>; rel=\"type\"");
+
+        final LinkHeaders linkHeaders = new LinkHeaders(headerValues);
+
+        assertEquals(new URI("http://example.com/foo"), linkHeaders.getUriByRel("describedby"));
+        assertNull(linkHeaders.getUriByRel("notalinkrelation"));
+
+        assertTrue(linkHeaders.contains("type", "http://example.com/modelA"));
+        assertFalse(linkHeaders.contains("type", "http://example.com/missingModel"));
+    }
+}


### PR DESCRIPTION
Aim to reduce the logging clutter on production, to make it easier to see and diagnose actual problems.

Also in this PR:

* Refactored link header handling into a separate utility class.
* Refactored code to get forwarded host (and port) into a separate method.
* Miscellaneous cleanup.

https://issues.umd.edu/browse/LIBFCREPO-1111