### PR TITLE
LIBFCREPO-1117. Check for null before converting URI to string.

### DIFF
--- a/src/main/java/edu/umd/lib/camel/processors/LdpathProcessor.java
+++ b/src/main/java/edu/umd/lib/camel/processors/LdpathProcessor.java
@@ -36,6 +36,7 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.io.StringReader;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.util.*;
 
@@ -217,13 +218,13 @@ public class LdpathProcessor implements Processor, Serializable {
         }
       }
       final LinkHeaders linkHeaders = new LinkHeaders(responseHeaders);
-      final String describedBy = linkHeaders.getUriByRel("describedby").toString();
+      final URI describedBy = linkHeaders.getUriByRel("describedby");
       final boolean nonRdfSource = linkHeaders.contains("type", NON_RDF_SOURCE_URI);
 
       if (nonRdfSource && (describedBy != null)) {
         logger.debug("For non-RDF resource {}, returning LinkedDataResourceUrl from 'describedBy' URI of {}",
                 containerBasedUri, describedBy);
-        return describedBy;
+        return describedBy.toString();
       }
     } catch(IOException ioe) {
       logger.error("I/O error retrieving HEAD {}", containerBasedUri);


### PR DESCRIPTION
Avoids a NullPointerException if there is no "describedby" link in the response.

https://issues.umd.edu/browse/LIBFCREPO-1117