### PR TITLE
LIBFCREPO-1246. Use umd-fcrepo-auth-utils dependency.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>edu.umd.lib</groupId>
   <artifactId>umd-camel-processors</artifactId>
-  <version>1.1.2</version>
+  <version>1.1.3-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>umd-camel-processors</name>
@@ -32,9 +32,8 @@
     </dependency>
     <dependency>
       <groupId>edu.umd.lib</groupId>
-      <artifactId>umd-fcrepo-webapp</artifactId>
-      <version>2.5.0</version>
-      <classifier>classes</classifier>
+      <artifactId>umd-fcrepo-auth-utils</artifactId>
+      <version>1.0.0</version>
       <type>jar</type>
     </dependency>
     <dependency>


### PR DESCRIPTION
Replacing umd-fcrepo-webapp with umd-fcrepo-auth-utils dependency.

https://umd-dit.atlassian.net/browse/LIBFCREPO-1246