### PR TITLE
LIBFCREPO-1586. Bumped umd-fcrepo-auth-utils version to 1.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>edu.umd.lib</groupId>
   <artifactId>umd-camel-processors</artifactId>
-  <version>1.1.3</version>
+  <version>1.1.4-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>umd-camel-processors</name>
@@ -16,10 +16,11 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <camel.version>2.25.2</camel.version>
+    <camel.version>2.25.4</camel.version>
     <jena.version>3.16.0</jena.version>
     <junit.version>4.13</junit.version>
     <ldpath.version>3.3.0</ldpath.version>
+    <umd.fcrepo.auth.utils.version>1.1.0</umd.fcrepo.auth.utils.version>
   </properties>
 
   <dependencies>
@@ -33,7 +34,7 @@
     <dependency>
       <groupId>edu.umd.lib</groupId>
       <artifactId>umd-fcrepo-auth-utils</artifactId>
-      <version>1.0.0</version>
+      <version>${umd.fcrepo.auth.utils.version}</version>
       <type>jar</type>
     </dependency>
     <dependency>


### PR DESCRIPTION
* this includes LDAP connection pooling
* also bumped camel version to 2.25.4 to match umd-fcrepo-messaging

https://umd-dit.atlassian.net/browse/LIBFCREPO-1586